### PR TITLE
fix: ensure special-characters in passwords (like backslashes)

### DIFF
--- a/src/main/java/io/github/asharapov/nexus/casc/internal/Interpolator.java
+++ b/src/main/java/io/github/asharapov/nexus/casc/internal/Interpolator.java
@@ -61,7 +61,7 @@ public class Interpolator extends ComponentSupport {
             }
 
             Pattern subexpr = Pattern.compile(Pattern.quote(matcher.group(0)));
-            str = subexpr.matcher(str).replaceAll(value);
+            str = subexpr.matcher(str).replaceAll(Matcher.quoteReplacement(value));
         }
 
         return str;


### PR DESCRIPTION
Using the interpolator to inject passwords/secrets was incorrect in specific cases when the secret contained special characters.. by quoting them we ensure the secrets integrity.

I tested the behavior with my setup and the maven tests succesfully completed.

Best regards

Lukas